### PR TITLE
implement cap reuse plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,5 +39,8 @@ mta_archives/
 app/*/dist
 resources/
 
+# Downloaded libraries
+app/incidents/webapp/lib/
+
 # VitePress
 _docs/.vitepress/cache

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "cap-reuse"]
+	path = cap-reuse
+	url = https://github.tools.sap/ux-ai/cap-reuse

--- a/app/incidents/package.json
+++ b/app/incidents/package.json
@@ -11,5 +11,7 @@
     "scripts": {
         "deploy-config": "npx -p @sap/ux-ui5-tooling fiori add deploy-config cf"
     },
-    "devDependencies": { }
+    "devDependencies": {
+        "ui5-middleware-simpleproxy": "^3.5.1"
+    }
 }

--- a/app/incidents/ui5.yaml
+++ b/app/incidents/ui5.yaml
@@ -2,3 +2,15 @@ specVersion: "2.5"
 metadata:
   name: ns.incidents
 type: application
+server:
+  customMiddleware:
+    - name: ui5-middleware-simpleproxy
+      mountPath: /odata/v4/processor
+      afterMiddleware: compression
+      configuration:
+        baseUri: http://localhost:4004/odata/v4/processor
+    - name: ui5-middleware-simpleproxy
+      mountPath: /sap/opu/odata4/sap/aiu_ui_prompt/srvd/sap/aiu_ui_prompt/0001
+      afterMiddleware: compression
+      configuration:
+        baseUri: http://localhost:4004/sap/opu/odata4/sap/aiu_ui_prompt/srvd/sap/aiu_ui_prompt/0001

--- a/app/incidents/webapp/test/flpSandbox.html
+++ b/app/incidents/webapp/test/flpSandbox.html
@@ -25,6 +25,34 @@
     <script type="text/javascript">
         window["sap-ushell-config"] = {
             defaultRenderer: "fiori2",
+            services: {
+                NavTargetResolution: {
+                    config: {
+                        enableClientSideTargetResolution: true
+                    }
+                },
+                ClientSideTargetResolution: {
+                    adapter: {
+                        config: {
+                            inbounds: {
+                                "IntelligentPrompt-summarize": {
+                                    semanticObject: "IntelligentPrompt",
+                                    action: "summarize",
+                                    signature: {
+                                        additionalParameters: "allowed",
+                                        parameters: {}
+                                    },
+                                    resolutionResult: {
+                                        applicationType: "SAPUI5",
+                                        ui5ComponentName: "ux.eng.fioriai.reuse",
+                                        url: "../lib/ux/eng/fioriai/reuse"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
             bootstrapPlugins: {
                 "RuntimeAuthoringPlugin": {
                     component: "sap.ushell.plugins.rta",
@@ -54,10 +82,10 @@
         };
     </script>
 
-    <script src="https://sapui5.hana.ondemand.com/1.120.0/test-resources/sap/ushell/bootstrap/sandbox.js" id="sap-ushell-bootstrap"></script>
+    <script src="https://sapui5.hana.ondemand.com/1.130.0/test-resources/sap/ushell/bootstrap/sandbox.js" id="sap-ushell-bootstrap"></script>
     <!-- Bootstrap the UI5 core library -->
     <script id="sap-ui-bootstrap"
-        src="https://sapui5.hana.ondemand.com/1.120.0/resources/sap-ui-core.js"
+        src="https://sapui5.hana.ondemand.com/1.130.0/resources/sap-ui-core.js"
         data-sap-ui-libs=""
         data-sap-ui-async="true"
         data-sap-ui-preload="async"
@@ -66,6 +94,13 @@
         data-sap-ui-language="en"
         data-sap-ui-resourceroots='{"ns.incidents": "../"}'
         data-sap-ui-frameOptions="allow"> // NON-SECURE setting for testing environment
+    </script>
+
+    <script>
+      sap.ui.getCore().attachInit(async () => {
+        const renderer = await sap.ushell.Container.createRenderer(true);
+        renderer.placeAt('content');
+      });
     </script>
 </head>
 

--- a/package.json
+++ b/package.json
@@ -3,23 +3,34 @@
   "version": "1.0.0",
   "dependencies": {
     "@sap/cds": ">=8",
-    "express": "^4"
+    "express": "^4",
+    "@ux-ai/cap-reuse": "*"
   },
   "devDependencies": {
     "@cap-js/cds-test": "*",
     "@cap-js/audit-logging": ">=0.8.3",
     "@cap-js/change-tracking": "^1.0.6",
     "@cap-js/attachments": "^2",
-    "@cap-js/sqlite": ">=1"
+    "@cap-js/sqlite": ">=1",
+    "concurrently": "^9.1.2"
   },
   "scripts": {
     "watch": "cds watch",
     "start": "cds-serve",
     "jest": "npx jest --silent",
-    "test": "chest"
+    "test": "chest",
+    "serve-hybrid": "concurrently --names \"CAP,UI5\" --prefix name \"cds bind -2 aicore && cds-tsx watch --profile hybrid\" \"cd app/incidents && npx ui5 serve --open test/flpSandbox.html\"",
+    "fetch:fioriaireuselib": "npm run download:fioriaireuselib && npm run extract:fioriaireuselib",
+    "download:fioriaireuselib": "mkdir -p temp && curl -f -L -o temp/fioriai-reuse.zip \"https://int.repositories.cloud.sap/artifactory/build-snapshots/com/sap/fiori/ux.eng.fioriai.reuse/2602.0.0-SNAPSHOT/ux.eng.fioriai.reuse-2602.0.0-SNAPSHOT-static-abap.zip\"",
+    "extract:fioriaireuselib": "mkdir -p app/incidents/webapp/lib/ux/eng/fioriai/reuse && unzip -o temp/fioriai-reuse.zip -d app/incidents/webapp/lib/ux/eng/fioriai/reuse && rm -rf temp",
+    "clean:fioriaireuselib": "rm -rf app/incidents/webapp/lib/ux/eng/fioriai/reuse temp",
+    "postinstall": "npm run fetch:fioriaireuselib"
   },
   "sapux": [
     "app/incidents"
+  ],
+  "workspaces": [
+    "cap-reuse"
   ],
   "private": true
 }


### PR DESCRIPTION
Test use of cap poc plugin into sample incidents scenario.

Steps as expected, with only difference being updating of ui5 in the webapp, since which version is reuse available? It is not in 1.20.

> Note: deployment was not verified.

